### PR TITLE
add `forceApplicationFormUrlEncoded` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.kotlin
 
 .gradle
 build/


### PR DESCRIPTION
add `forceApplicationFormUrlEncoded` option to set content-type as "application/x-www-form-urlencoded"

----

AT Protocol の OAuth の PAR で `Content-Type: application/x-www-form-urlencoded` が必要だったので追加しました。