### PR TITLE
fix: use native browser WebSocket API on JS target

### DIFF
--- a/src/commonMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
+++ b/src/commonMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
@@ -1,147 +1,49 @@
 package work.socialhub.khttpclient.websocket
 
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
-import io.ktor.client.plugins.websocket.WebSockets
-import io.ktor.client.plugins.websocket.pingInterval
-import io.ktor.client.plugins.websocket.webSocket
-import io.ktor.client.request.headers
-import io.ktor.client.request.url
-import io.ktor.http.HttpMethod
-import io.ktor.http.URLBuilder
-import io.ktor.http.takeFrom
-import io.ktor.websocket.Frame
-import io.ktor.websocket.readBytes
-import io.ktor.websocket.readText
-import io.ktor.websocket.send
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
-import work.socialhub.khttpclient.internal.applySystemProxy
-import kotlin.time.Duration.Companion.milliseconds
+expect class WebsocketRequest() {
 
-class WebsocketRequest {
+    var schema: String
+    var host: String?
+    var path: String?
+    var port: Int?
+    var url: String?
 
-    var schema: String = "ws"
-    var host: String? = null
-    var path: String? = null
-    var port: Int? = null
-    var url: String? = null
+    var accept: String?
+    var userAgent: String?
+    val header: MutableMap<String, String>
 
-    var accept: String? = null
-    var userAgent: String? = "kHttpClient/1.0"
-    val header = mutableMapOf<String, String>()
+    var textListener: suspend (String) -> Unit
+    var bytesListener: suspend (ByteArray) -> Unit
 
-    var textListener: suspend (String) -> Unit = {}
-    var bytesListener: suspend (ByteArray) -> Unit = {}
-
-    var onOpenListener: (WebsocketRequest) -> Unit = {}
-    var onCloseListener: (WebsocketRequest) -> Unit = {}
-    var onErrorListener: (Exception) -> Unit = { }
+    var onOpenListener: (WebsocketRequest) -> Unit
+    var onCloseListener: (WebsocketRequest) -> Unit
+    var onErrorListener: (Exception) -> Unit
 
     // Basic
-    fun schema(schema: String) = also { it.schema = schema }
-    fun host(host: String) = also { it.host = host }
-    fun path(path: String) = also { it.path = path }
-    fun port(port: Int?) = also { it.port = port }
-    fun url(url: String?) = also { it.url = url }
+    fun schema(schema: String): WebsocketRequest
+    fun host(host: String): WebsocketRequest
+    fun path(path: String): WebsocketRequest
+    fun port(port: Int?): WebsocketRequest
+    fun url(url: String?): WebsocketRequest
 
     // Listener
-    fun textListener(listener: suspend (String) -> Unit) = also { it.textListener = listener }
-    fun bytesListener(listener: suspend (ByteArray) -> Unit) = also { it.bytesListener = listener }
-    fun onOpenListener(listener: (WebsocketRequest) -> Unit) = also { it.onOpenListener = listener }
-    fun onCloseListener(listener: (WebsocketRequest) -> Unit) = also { it.onCloseListener = listener }
-    fun onErrorListener(listener: (Exception) -> Unit) = also { it.onErrorListener = listener }
+    fun textListener(listener: suspend (String) -> Unit): WebsocketRequest
+    fun bytesListener(listener: suspend (ByteArray) -> Unit): WebsocketRequest
+    fun onOpenListener(listener: (WebsocketRequest) -> Unit): WebsocketRequest
+    fun onCloseListener(listener: (WebsocketRequest) -> Unit): WebsocketRequest
+    fun onErrorListener(listener: (Exception) -> Unit): WebsocketRequest
 
     // Headers
-    fun accept(accept: String) = also { it.accept = accept }
-    fun userAgent(userAgent: String) = also { it.userAgent = userAgent }
-    fun header(key: String, value: String) = also { it.header[key] = value }
-
-    private val client = HttpClient {
-        applySystemProxy()
-        install(WebSockets) {
-            pingInterval = 20_000.milliseconds
-        }
-    }
-
-    private var session: DefaultClientWebSocketSession? = null
+    fun accept(accept: String): WebsocketRequest
+    fun userAgent(userAgent: String): WebsocketRequest
+    fun header(key: String, value: String): WebsocketRequest
 
     // Start
-    suspend fun open() = start(HttpMethod.Get)
-    suspend fun openPost() = start(HttpMethod.Post)
+    suspend fun open(): WebsocketRequest
+    suspend fun openPost(): WebsocketRequest
 
-    suspend fun start(method: HttpMethod) = also {
-        val req = this
-        accept?.let { header["Accept"] = it }
-        userAgent?.let { header["User-Agent"] = it }
+    fun close()
 
-        client.webSocket({
-            this.method = method
-            if (req.url != null) {
-                val tmp = checkNotNull(req.url)
-                this.url.takeFrom(URLBuilder(tmp))
-            } else {
-                this.url(
-                    req.schema,
-                    req.host,
-                    req.port,
-                    req.path,
-                )
-            }
-            this.headers {
-                req.header.forEach { (k, v) ->
-                    append(k, v)
-                }
-            }
-        }) {
-            try {
-                session = this
-                req.onOpenListener(req)
-
-                for (frame in incoming) {
-                    when (frame) {
-                        is Frame.Text -> {
-                            launch { textListener(frame.readText()) }
-                        }
-
-                        is Frame.Binary -> {
-                            launch { bytesListener(frame.readBytes()) }
-                        }
-
-                        else -> {}
-                    }
-                }
-            } catch (e: Exception) {
-                // call when error caused
-                req.onErrorListener(e)
-            } finally {
-                // call when close
-                req.onCloseListener(req)
-            }
-        }
-    }
-
-    fun close() {
-        onCloseListener(this)
-        client.coroutineContext.cancel()
-        client.close()
-        session = null
-    }
-
-    suspend fun sendText(text: String) {
-        checkNotNull(session).let {
-            if (it.isActive) {
-                it.send(text)
-            }
-        }
-    }
-
-    suspend fun sendBinary(content: ByteArray) {
-        checkNotNull(session).let {
-            if (it.isActive) {
-                it.send(content)
-            }
-        }
-    }
+    suspend fun sendText(text: String)
+    suspend fun sendBinary(content: ByteArray)
 }

--- a/src/jsMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
+++ b/src/jsMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
@@ -1,0 +1,139 @@
+package work.socialhub.khttpclient.websocket
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.w3c.dom.WebSocket
+import org.w3c.dom.events.Event
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Int8Array
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.Job
+
+actual class WebsocketRequest {
+
+    actual var schema: String = "ws"
+    actual var host: String? = null
+    actual var path: String? = null
+    actual var port: Int? = null
+    actual var url: String? = null
+
+    actual var accept: String? = null
+    actual var userAgent: String? = "kHttpClient/1.0"
+    actual val header = mutableMapOf<String, String>()
+
+    actual var textListener: suspend (String) -> Unit = {}
+    actual var bytesListener: suspend (ByteArray) -> Unit = {}
+
+    actual var onOpenListener: (WebsocketRequest) -> Unit = {}
+    actual var onCloseListener: (WebsocketRequest) -> Unit = {}
+    actual var onErrorListener: (Exception) -> Unit = {}
+
+    // Basic
+    actual fun schema(schema: String) = also { it.schema = schema }
+    actual fun host(host: String) = also { it.host = host }
+    actual fun path(path: String) = also { it.path = path }
+    actual fun port(port: Int?) = also { it.port = port }
+    actual fun url(url: String?) = also { it.url = url }
+
+    // Listener
+    actual fun textListener(listener: suspend (String) -> Unit) = also { it.textListener = listener }
+    actual fun bytesListener(listener: suspend (ByteArray) -> Unit) = also { it.bytesListener = listener }
+    actual fun onOpenListener(listener: (WebsocketRequest) -> Unit) = also { it.onOpenListener = listener }
+    actual fun onCloseListener(listener: (WebsocketRequest) -> Unit) = also { it.onCloseListener = listener }
+    actual fun onErrorListener(listener: (Exception) -> Unit) = also { it.onErrorListener = listener }
+
+    // Headers
+    actual fun accept(accept: String) = also { it.accept = accept }
+    actual fun userAgent(userAgent: String) = also { it.userAgent = userAgent }
+    actual fun header(key: String, value: String) = also { it.header[key] = value }
+
+    private var ws: WebSocket? = null
+    private var closed = CompletableDeferred<Unit>()
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    actual suspend fun open(): WebsocketRequest = start()
+    actual suspend fun openPost(): WebsocketRequest = start()
+
+    private suspend fun start(): WebsocketRequest {
+        val wsUrl = buildUrl()
+        val opened = CompletableDeferred<Unit>()
+        closed = CompletableDeferred()
+
+        val socket = WebSocket(wsUrl)
+        socket.binaryType = "arraybuffer".unsafeCast<org.w3c.dom.BinaryType>()
+        ws = socket
+
+        socket.onopen = {
+            onOpenListener(this)
+            opened.complete(Unit)
+        }
+
+        socket.onclose = {
+            if (!opened.isCompleted) {
+                opened.completeExceptionally(RuntimeException("WebSocket closed before open"))
+            }
+            onCloseListener(this)
+            closed.complete(Unit)
+        }
+
+        socket.onerror = { _: Event ->
+            val ex = RuntimeException("WebSocket error")
+            onErrorListener(ex)
+            if (!opened.isCompleted) {
+                opened.completeExceptionally(ex)
+            }
+        }
+
+        socket.onmessage = { event ->
+            val data = event.data
+            when (data) {
+                is String -> {
+                    scope.launch { textListener(data) }
+                }
+                is ArrayBuffer -> {
+                    val bytes = Int8Array(data).unsafeCast<ByteArray>()
+                    scope.launch { bytesListener(bytes) }
+                }
+            }
+        }
+
+        // Cancel WebSocket when parent coroutine is cancelled
+        coroutineContext[Job]?.invokeOnCompletion {
+            ws?.close()
+            scope.cancel()
+        }
+
+        opened.await()
+        closed.await()
+        return this
+    }
+
+    private fun buildUrl(): String {
+        url?.let { return it }
+
+        val s = if (schema == "ws" || schema == "wss") schema else "wss"
+        val h = checkNotNull(host) { "host must be set" }
+        val p = port?.let { ":$it" } ?: ""
+        val pathPart = path?.let { if (it.startsWith("/")) it else "/$it" } ?: ""
+        return "$s://$h$p$pathPart"
+    }
+
+    actual fun close() {
+        ws?.close()
+        ws = null
+        closed.complete(Unit)
+        scope.cancel()
+    }
+
+    actual suspend fun sendText(text: String) {
+        checkNotNull(ws) { "WebSocket is not connected" }.send(text)
+    }
+
+    actual suspend fun sendBinary(content: ByteArray) {
+        checkNotNull(ws) { "WebSocket is not connected" }.send(content.unsafeCast<org.khronos.webgl.ArrayBufferView>())
+    }
+}

--- a/src/jsMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
+++ b/src/jsMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
@@ -46,37 +46,50 @@ actual class WebsocketRequest {
     actual fun onCloseListener(listener: (WebsocketRequest) -> Unit) = also { it.onCloseListener = listener }
     actual fun onErrorListener(listener: (Exception) -> Unit) = also { it.onErrorListener = listener }
 
-    // Headers
+    // Headers (browser WebSocket API does not support custom headers)
     actual fun accept(accept: String) = also { it.accept = accept }
     actual fun userAgent(userAgent: String) = also { it.userAgent = userAgent }
     actual fun header(key: String, value: String) = also { it.header[key] = value }
 
     private var ws: WebSocket? = null
     private var closed = CompletableDeferred<Unit>()
+    private var closeCalled = false
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     actual suspend fun open(): WebsocketRequest = start()
-    actual suspend fun openPost(): WebsocketRequest = start()
+
+    actual suspend fun openPost(): WebsocketRequest {
+        throw UnsupportedOperationException("WebSocket POST handshake is not supported on JS target")
+    }
 
     private suspend fun start(): WebsocketRequest {
         val wsUrl = buildUrl()
         val opened = CompletableDeferred<Unit>()
         closed = CompletableDeferred()
+        closeCalled = false
 
         val socket = WebSocket(wsUrl)
         socket.binaryType = "arraybuffer".unsafeCast<org.w3c.dom.BinaryType>()
         ws = socket
 
         socket.onopen = {
-            onOpenListener(this)
             opened.complete(Unit)
+            try {
+                onOpenListener(this)
+            } catch (e: Throwable) {
+                onErrorListener(RuntimeException("onOpenListener failed", e))
+            }
         }
 
         socket.onclose = {
+            ws = null
             if (!opened.isCompleted) {
                 opened.completeExceptionally(RuntimeException("WebSocket closed before open"))
             }
-            onCloseListener(this)
+            if (!closeCalled) {
+                closeCalled = true
+                onCloseListener(this)
+            }
             closed.complete(Unit)
         }
 
@@ -101,7 +114,6 @@ actual class WebsocketRequest {
             }
         }
 
-        // Cancel WebSocket when parent coroutine is cancelled
         coroutineContext[Job]?.invokeOnCompletion {
             ws?.close()
             scope.cancel()
@@ -123,6 +135,10 @@ actual class WebsocketRequest {
     }
 
     actual fun close() {
+        if (!closeCalled) {
+            closeCalled = true
+            onCloseListener(this)
+        }
         ws?.close()
         ws = null
         closed.complete(Unit)
@@ -130,10 +146,12 @@ actual class WebsocketRequest {
     }
 
     actual suspend fun sendText(text: String) {
-        checkNotNull(ws) { "WebSocket is not connected" }.send(text)
+        val socket = ws ?: throw IllegalStateException("WebSocket is not connected")
+        socket.send(text)
     }
 
     actual suspend fun sendBinary(content: ByteArray) {
-        checkNotNull(ws) { "WebSocket is not connected" }.send(content.unsafeCast<org.khronos.webgl.ArrayBufferView>())
+        val socket = ws ?: throw IllegalStateException("WebSocket is not connected")
+        socket.send(content.unsafeCast<org.khronos.webgl.ArrayBufferView>())
     }
 }

--- a/src/jvmMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
+++ b/src/jvmMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
@@ -1,0 +1,145 @@
+package work.socialhub.khttpclient.websocket
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.pingInterval
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.client.request.headers
+import io.ktor.client.request.url
+import io.ktor.http.HttpMethod
+import io.ktor.http.URLBuilder
+import io.ktor.http.takeFrom
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readBytes
+import io.ktor.websocket.readText
+import io.ktor.websocket.send
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import work.socialhub.khttpclient.internal.applySystemProxy
+import kotlin.time.Duration.Companion.milliseconds
+
+actual class WebsocketRequest {
+
+    actual var schema: String = "ws"
+    actual var host: String? = null
+    actual var path: String? = null
+    actual var port: Int? = null
+    actual var url: String? = null
+
+    actual var accept: String? = null
+    actual var userAgent: String? = "kHttpClient/1.0"
+    actual val header = mutableMapOf<String, String>()
+
+    actual var textListener: suspend (String) -> Unit = {}
+    actual var bytesListener: suspend (ByteArray) -> Unit = {}
+
+    actual var onOpenListener: (WebsocketRequest) -> Unit = {}
+    actual var onCloseListener: (WebsocketRequest) -> Unit = {}
+    actual var onErrorListener: (Exception) -> Unit = {}
+
+    // Basic
+    actual fun schema(schema: String) = also { it.schema = schema }
+    actual fun host(host: String) = also { it.host = host }
+    actual fun path(path: String) = also { it.path = path }
+    actual fun port(port: Int?) = also { it.port = port }
+    actual fun url(url: String?) = also { it.url = url }
+
+    // Listener
+    actual fun textListener(listener: suspend (String) -> Unit) = also { it.textListener = listener }
+    actual fun bytesListener(listener: suspend (ByteArray) -> Unit) = also { it.bytesListener = listener }
+    actual fun onOpenListener(listener: (WebsocketRequest) -> Unit) = also { it.onOpenListener = listener }
+    actual fun onCloseListener(listener: (WebsocketRequest) -> Unit) = also { it.onCloseListener = listener }
+    actual fun onErrorListener(listener: (Exception) -> Unit) = also { it.onErrorListener = listener }
+
+    // Headers
+    actual fun accept(accept: String) = also { it.accept = accept }
+    actual fun userAgent(userAgent: String) = also { it.userAgent = userAgent }
+    actual fun header(key: String, value: String) = also { it.header[key] = value }
+
+    private val client = HttpClient {
+        applySystemProxy()
+        install(WebSockets) {
+            pingInterval = 20_000.milliseconds
+        }
+    }
+
+    private var session: DefaultClientWebSocketSession? = null
+
+    // Start
+    actual suspend fun open() = start(HttpMethod.Get)
+    actual suspend fun openPost() = start(HttpMethod.Post)
+
+    private suspend fun start(method: HttpMethod) = also {
+        val req = this
+        accept?.let { header["Accept"] = it }
+        userAgent?.let { header["User-Agent"] = it }
+
+        client.webSocket({
+            this.method = method
+            if (req.url != null) {
+                val tmp = checkNotNull(req.url)
+                this.url.takeFrom(URLBuilder(tmp))
+            } else {
+                this.url(
+                    req.schema,
+                    req.host,
+                    req.port,
+                    req.path,
+                )
+            }
+            this.headers {
+                req.header.forEach { (k, v) ->
+                    append(k, v)
+                }
+            }
+        }) {
+            try {
+                session = this
+                req.onOpenListener(req)
+
+                for (frame in incoming) {
+                    when (frame) {
+                        is Frame.Text -> {
+                            launch { textListener(frame.readText()) }
+                        }
+
+                        is Frame.Binary -> {
+                            launch { bytesListener(frame.readBytes()) }
+                        }
+
+                        else -> {}
+                    }
+                }
+            } catch (e: Exception) {
+                req.onErrorListener(e)
+            } finally {
+                req.onCloseListener(req)
+            }
+        }
+    }
+
+    actual fun close() {
+        onCloseListener(this)
+        client.coroutineContext.cancel()
+        client.close()
+        session = null
+    }
+
+    actual suspend fun sendText(text: String) {
+        checkNotNull(session).let {
+            if (it.isActive) {
+                it.send(text)
+            }
+        }
+    }
+
+    actual suspend fun sendBinary(content: ByteArray) {
+        checkNotNull(session).let {
+            if (it.isActive) {
+                it.send(content)
+            }
+        }
+    }
+}

--- a/src/nativeMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
+++ b/src/nativeMain/kotlin/work/socialhub/khttpclient/websocket/WebsocketRequest.kt
@@ -1,0 +1,145 @@
+package work.socialhub.khttpclient.websocket
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.pingInterval
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.client.request.headers
+import io.ktor.client.request.url
+import io.ktor.http.HttpMethod
+import io.ktor.http.URLBuilder
+import io.ktor.http.takeFrom
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readBytes
+import io.ktor.websocket.readText
+import io.ktor.websocket.send
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import work.socialhub.khttpclient.internal.applySystemProxy
+import kotlin.time.Duration.Companion.milliseconds
+
+actual class WebsocketRequest {
+
+    actual var schema: String = "ws"
+    actual var host: String? = null
+    actual var path: String? = null
+    actual var port: Int? = null
+    actual var url: String? = null
+
+    actual var accept: String? = null
+    actual var userAgent: String? = "kHttpClient/1.0"
+    actual val header = mutableMapOf<String, String>()
+
+    actual var textListener: suspend (String) -> Unit = {}
+    actual var bytesListener: suspend (ByteArray) -> Unit = {}
+
+    actual var onOpenListener: (WebsocketRequest) -> Unit = {}
+    actual var onCloseListener: (WebsocketRequest) -> Unit = {}
+    actual var onErrorListener: (Exception) -> Unit = {}
+
+    // Basic
+    actual fun schema(schema: String) = also { it.schema = schema }
+    actual fun host(host: String) = also { it.host = host }
+    actual fun path(path: String) = also { it.path = path }
+    actual fun port(port: Int?) = also { it.port = port }
+    actual fun url(url: String?) = also { it.url = url }
+
+    // Listener
+    actual fun textListener(listener: suspend (String) -> Unit) = also { it.textListener = listener }
+    actual fun bytesListener(listener: suspend (ByteArray) -> Unit) = also { it.bytesListener = listener }
+    actual fun onOpenListener(listener: (WebsocketRequest) -> Unit) = also { it.onOpenListener = listener }
+    actual fun onCloseListener(listener: (WebsocketRequest) -> Unit) = also { it.onCloseListener = listener }
+    actual fun onErrorListener(listener: (Exception) -> Unit) = also { it.onErrorListener = listener }
+
+    // Headers
+    actual fun accept(accept: String) = also { it.accept = accept }
+    actual fun userAgent(userAgent: String) = also { it.userAgent = userAgent }
+    actual fun header(key: String, value: String) = also { it.header[key] = value }
+
+    private val client = HttpClient {
+        applySystemProxy()
+        install(WebSockets) {
+            pingInterval = 20_000.milliseconds
+        }
+    }
+
+    private var session: DefaultClientWebSocketSession? = null
+
+    // Start
+    actual suspend fun open() = start(HttpMethod.Get)
+    actual suspend fun openPost() = start(HttpMethod.Post)
+
+    private suspend fun start(method: HttpMethod) = also {
+        val req = this
+        accept?.let { header["Accept"] = it }
+        userAgent?.let { header["User-Agent"] = it }
+
+        client.webSocket({
+            this.method = method
+            if (req.url != null) {
+                val tmp = checkNotNull(req.url)
+                this.url.takeFrom(URLBuilder(tmp))
+            } else {
+                this.url(
+                    req.schema,
+                    req.host,
+                    req.port,
+                    req.path,
+                )
+            }
+            this.headers {
+                req.header.forEach { (k, v) ->
+                    append(k, v)
+                }
+            }
+        }) {
+            try {
+                session = this
+                req.onOpenListener(req)
+
+                for (frame in incoming) {
+                    when (frame) {
+                        is Frame.Text -> {
+                            launch { textListener(frame.readText()) }
+                        }
+
+                        is Frame.Binary -> {
+                            launch { bytesListener(frame.readBytes()) }
+                        }
+
+                        else -> {}
+                    }
+                }
+            } catch (e: Exception) {
+                req.onErrorListener(e)
+            } finally {
+                req.onCloseListener(req)
+            }
+        }
+    }
+
+    actual fun close() {
+        onCloseListener(this)
+        client.coroutineContext.cancel()
+        client.close()
+        session = null
+    }
+
+    actual suspend fun sendText(text: String) {
+        checkNotNull(session).let {
+            if (it.isActive) {
+                it.send(text)
+            }
+        }
+    }
+
+    actual suspend fun sendBinary(content: ByteArray) {
+        checkNotNull(session).let {
+            if (it.isActive) {
+                it.send(content)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ktor 3.5.0's WebSocket plugin throws NPE on JS due to useEngineDispatcher=true accessing a null coroutine dispatcher.

Convert WebsocketRequest to expect/actual:
- JVM/Native: keep existing Ktor-based implementation
- JS: use browser's native WebSocket API directly, bypassing Ktor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured WebSocket module for consistent cross-platform support across JavaScript, JVM, and native environments while maintaining a unified API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->